### PR TITLE
Added version information

### DIFF
--- a/custom_components/phonetrack/manifest.json
+++ b/custom_components/phonetrack/manifest.json
@@ -2,6 +2,7 @@
   "domain": "phonetrack",
   "name": "PhoneTrack",
   "documentation": "https://github.com/j1nx/homeassistant-phonetrack",
+  "version": "0.1",
   "requirements": [],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
Home Assistant started throwing warnings about missing version information in this custom component (which I've used for a long time now and loving it). So I added the version information to the manifest file.  
I wasn't sure what version this is, so I put '0.1' in there. Not sure if this is desired, but can of course easily be changed.  
I've tested this change on my HA server (version core-2021.3.4 running in docker) and the warning went away