### PR TITLE
Adding version 1.0.0 to manifest

### DIFF
--- a/custom_components/phonetrack/manifest.json
+++ b/custom_components/phonetrack/manifest.json
@@ -3,6 +3,7 @@
   "name": "PhoneTrack",
   "documentation": "https://github.com/j1nx/homeassistant-phonetrack",
   "requirements": [],
+  "version": "1.0.0",
   "dependencies": [],
   "codeowners": [
     "@Phyks",


### PR DESCRIPTION
Adding version to manifest

FYI
Component seems to be working fine with Home Assistant Core 2022.6.6