### PR TITLE
device tracker "source_type" corrected

### DIFF
--- a/custom_components/phonetrack/device_tracker.py
+++ b/custom_components/phonetrack/device_tracker.py
@@ -109,7 +109,7 @@ class PhoneTrackDeviceTracker:  # pylint: disable=too-few-public-methods
             self.see(
                 dev_id=slugify(device),
                 gps=(lat, lon),
-                source_type=GPS,
+                source_type=SourceType.GPS,
                 gps_accuracy=accuracy,
                 battery=battery,
             )


### PR DESCRIPTION
This corrects the "source_type" to be SourceType.GPS which is required for HA Core > 2024