### PR TITLE
gps now found with source_type="gps", no import needed

### DIFF
--- a/custom_components/phonetrack/device_tracker.py
+++ b/custom_components/phonetrack/device_tracker.py
@@ -9,7 +9,6 @@ import requests  # type: ignore[import]
 import voluptuous as vol  # type: ignore[import]
 from homeassistant.components.device_tracker import (  # type: ignore[import]
     PLATFORM_SCHEMA,
-    SourceType,
     SeeCallback,
 )
 from homeassistant.const import CONF_DEVICES  # type: ignore[import]
@@ -118,7 +117,7 @@ class PhoneTrackDeviceTracker:  # pylint: disable=too-few-public-methods
             self.see(
                 dev_id=slugify(device),
                 gps=(lat, lon),
-                source_type=SourceType.GPS,
+                source_type="gps",
                 gps_accuracy=accuracy,
                 battery=battery,
             )


### PR DESCRIPTION
https://community.home-assistant.io/t/device-tracker-see-sets-source-type-to-gps/710099

GPS coordinates are now retrieved without importing anything from home-assistant, just use `source_type="gps"`

(thanks to LLMs for figuring this out)

It works for me.